### PR TITLE
added checklist feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+build
+
 .moc
 .obj
 .uic

--- a/src/documentio.cpp
+++ b/src/documentio.cpp
@@ -700,7 +700,7 @@ void DocumentIO::exportBrickLinkWantedListClipboard(const LotList &lots)
         XmlHelpers::CreateXML xml("INVENTORY", "ITEM");
 
         for (const Lot *lot : lots) {
-            if (lot->isIncomplete() || (lot->status() == BrickLink::Status::Exclude))
+            if (lot->isIncomplete() || (lot->status() == BrickLink::Status::Exclude) || (lot->quantity() == 0))
                 continue;
 
             xml.createElement();

--- a/src/framework.cpp
+++ b/src/framework.cpp
@@ -875,13 +875,15 @@ void FrameWork::translateActions()
         { "edit_color",                     tr("Set color..."),                       },
         { "edit_qty",                       tr("Quantity"),                           },
         { "edit_qty_set",                   tr("Set quantity..."),                    },
+        { "edit_qty_need",                  tr("Need it..."),                         tr("Ctrl++", "Edit|Quantity|Need it")},
+        { "edit_qty_have",                  tr("Have it..."),                         tr("Ctrl+-", "Edit|Quantity|Have it")},
         { "edit_qty_multiply",              tr("Multiply quantity..."),               tr("Ctrl+*", "Edit|Quantity|Multiply") },
         { "edit_qty_divide",                tr("Divide quantity..."),                 tr("Ctrl+/", "Edit|Quantity|Divide") },
         { "edit_price",                     tr("Price"),                              },
         { "edit_price_round",               tr("Round price to 2 decimals"),          },
         { "edit_price_set",                 tr("Set price..."),                       },
         { "edit_price_to_priceguide",       tr("Set price to guide..."),              tr("Ctrl+G", "Edit|Price|Set to PriceGuide") },
-        { "edit_price_inc_dec",             tr("Adjust price..."),                    tr("Ctrl++", "Edit|Price|Inc/Dec") },
+        { "edit_price_inc_dec",             tr("Adjust price..."),                    tr("Ctrl+=", "Edit|Price|Inc/Dec") },
         { "edit_cost",                      tr("Cost"),                               },
         { "edit_cost_round",                tr("Round cost to 2 decimals") ,          },
         { "edit_cost_set",                  tr("Set cost..."),                        },
@@ -1303,6 +1305,8 @@ void FrameWork::createActions()
 
     m = newQMenu(this, "edit_qty", NeedSelection(1));
     m->addAction(newQAction(this, "edit_qty_set", NeedSelection(1)));
+    m->addAction(newQAction(this, "edit_qty_need", NeedSelection(1)));
+    m->addAction(newQAction(this, "edit_qty_have", NeedSelection(1)));
     m->addAction(newQAction(this, "edit_qty_multiply", NeedSelection(1)));
     m->addAction(newQAction(this, "edit_qty_divide", NeedSelection(1)));
 

--- a/src/view.cpp
+++ b/src/view.cpp
@@ -2148,6 +2148,47 @@ void View::on_edit_cost_spread_triggered()
     }
 }
 
+
+void View::on_edit_qty_need_triggered()
+{
+    if (selectedLots().isEmpty())
+        return;
+
+    applyTo(selectedLots(), [=](const auto &from, auto &to)
+            {
+                int quantity = from.quantity();
+
+                quantity += 1;
+
+                if (quantity >= 0)
+                {
+                    (to = from).setQuantity(quantity);
+                    return true;
+                }
+                return false;
+            });
+}
+
+void View::on_edit_qty_have_triggered()
+{
+    if (selectedLots().isEmpty())
+        return;
+
+    applyTo(selectedLots(), [=](const auto &from, auto &to)
+            {
+                int quantity = from.quantity();
+
+                quantity -= 1;
+
+                if (quantity >= 0)
+                {
+                    (to = from).setQuantity(quantity);
+                    return true;
+                }
+                return false;
+            });
+}
+
 void View::on_edit_qty_divide_triggered()
 {
     if (selectedLots().isEmpty())
@@ -2762,7 +2803,7 @@ void View::contextMenu(const QPoint &pos)
         case Document::QuantityOrig:
         case Document::QuantityDiff:
         case Document::Quantity:
-            actionNames = { "edit_qty_set", "edit_qty_multiply", "edit_qty_divide" };
+            actionNames = { "edit_qty_set", "edit_qty_need", "edit_qty_have", "edit_qty_multiply", "edit_qty_divide" };
             break;
         case Document::PriceOrig:
         case Document::PriceDiff:

--- a/src/view.h
+++ b/src/view.h
@@ -154,6 +154,8 @@ public slots:
     void on_edit_color_triggered();
     void on_edit_item_triggered();
     void on_edit_qty_set_triggered();
+    void on_edit_qty_need_triggered();
+    void on_edit_qty_have_triggered();
     void on_edit_qty_multiply_triggered();
     void on_edit_qty_divide_triggered();
     void on_edit_price_set_triggered();


### PR DESCRIPTION
## User Story
As a builder who is trying to reassemble a set from their pieces [or purchase missing pieces], I need an intuitive way to treat the set inventory as a checklist.

### Proposed Solution
When rebuilding a set it is helpful to use the set inventory as a starting checklist. As we sift through our parts and put aside the ones needed for the rebuild, the part quantities on the set inventory can then be adjusted to reflect the parts [and associated costs] still needed to complete the set. This can then be exported as a Wanted list and lots can be purchased as necessary.

In order to assist with this workflow, two new menu options have been added under Edit->Quantity:
Need it... [Ctrl+]
Have it... [Ctrl-]

These increment and decrement the selected lots to reflect the current checklist status.

Edit->Price->Adjust Price had it's shortcut changed to Ctrl= b/c it was formerly Ctrl+

And finally exporting a BrickLink Wanted list will no longer include lots that have 0 quantity. That way the checklist still shows the lots needed with a quantity of 0 but we don't pollute our Wanted lists with them.

Thanks for your consideration.