### PR TITLE
Added price per kilo column

### DIFF
--- a/src/bricklink/lot.h
+++ b/src/bricklink/lot.h
@@ -86,6 +86,7 @@ public:
     int tierQuantity(int i) const      { return m_tier_quantity [qBound(0, i, 2)]; }
     void setTierQuantity(int i, int q) { m_tier_quantity [qBound(0, i, 2)] = q; }
     double price() const               { return m_price; }
+    double priceKilo() const           { return price() > 0 && weight() > 0 ? price() / weight() * 1000 : 0; }
     void setPrice(double p)            { m_price = p; }
     double tierPrice(int i) const      { return m_tier_price[qBound(0, i, 2)]; }
     void setTierPrice(int i, double p) { m_tier_price[qBound(0, i, 2)] = p; }

--- a/src/common/document.cpp
+++ b/src/common/document.cpp
@@ -1863,6 +1863,7 @@ QVector<ColumnData> Document::defaultColumnLayout(bool simpleMode)
         DocumentModel::PriceDiff,
         DocumentModel::Price,
         DocumentModel::Total,
+        DocumentModel::PriceKilo,
         DocumentModel::Cost,
         DocumentModel::Bulk,
         DocumentModel::Sale,
@@ -1904,6 +1905,7 @@ QVector<ColumnData> Document::defaultColumnLayout(bool simpleMode)
         DocumentModel::DateLastSold,
         DocumentModel::PriceOrig,
         DocumentModel::PriceDiff,
+        DocumentModel::PriceKilo,
         DocumentModel::QuantityOrig,
         DocumentModel::QuantityDiff,
     };

--- a/src/common/documentmodel.cpp
+++ b/src/common/documentmodel.cpp
@@ -1634,6 +1634,16 @@ void DocumentModel::initializeColumns()
               return doubleCompare(l1->total(), l2->total());
           },
       });
+    C(PriceKilo, Column {
+          .defaultWidth = 15,
+          .alignment = Qt::AlignRight,
+          .editable = false,
+          .title = QT_TR_NOOP("Price / kg"),
+          .displayFn = [&](const Lot *lot) { return lot->priceKilo(); },
+          .compareFn = [&](const Lot *l1, const Lot *l2) {
+              return doubleCompare(l1->priceKilo(), l2->priceKilo());
+          },
+      });
     C(Sale, Column {
           .defaultWidth = 5,
           .alignment = Qt::AlignRight,

--- a/src/common/documentmodel.h
+++ b/src/common/documentmodel.h
@@ -61,6 +61,7 @@ public:
         PriceDiff,
         Price,
         Total,
+        PriceKilo,
         Cost,
         Bulk,
         Sale,

--- a/src/desktop/documentdelegate.cpp
+++ b/src/desktop/documentdelegate.cpp
@@ -1108,6 +1108,7 @@ QString DocumentDelegate::displayData(const QModelIndex &idx, const QVariant &di
     case DocumentModel::PriceDiff:
     case DocumentModel::Price:
     case DocumentModel::Total:
+    case DocumentModel::PriceKilo:
     case DocumentModel::Cost:
     case DocumentModel::TierP1:
     case DocumentModel::TierP2:

--- a/src/mobile/View.qml
+++ b/src/mobile/View.qml
@@ -235,6 +235,7 @@ Page {
                         tint: Qt.rgba(1, 1, 0, .1)
                     }
                 }
+                DelegateChoice { roleValue: Document.PriceKilo; delegate: currencyDelegate }
                 DelegateChoice { roleValue: Document.Cost; delegate: currencyDelegate }
                 DelegateChoice { roleValue: Document.TierP1
                     GridCell {


### PR DESCRIPTION
Often (at least in The Netherlands) LEGO is sold by weight (with a price per kilo). Therefore, it is handy when you can see the (average) price per kilo of bricks so you know if you should add it to your buy.

_Branch main doesn't build (on MacOS), so I branched from master and set the PR target to master as well_