### PR TITLE
Take lot quantity into account in `consistsOf` list creation

### DIFF
--- a/src/bricklink/qmlapi.cpp
+++ b/src/bricklink/qmlapi.cpp
@@ -344,6 +344,7 @@ QVariantList QmlItem::consistsOf() const
     result.reserve(consists.size());
     for (const auto &co : consists) {
         auto *lot = new Lot { co.item(), co.color() };
+        lot->setQuantity(co.quantity());
         lot->setAlternate(co.isAlternate());
         lot->setAlternateId(co.alternateId());
         lot->setCounterPart(co.isCounterPart());


### PR DESCRIPTION
Currently all lots within the list have quantity "0", making it impossible to do any quantity related things in extension scripts.