### PR TITLE
fix: add missing include of QtCore/QJsonValue in src/bricklink/order.cpp

### DIFF
--- a/src/bricklink/order.cpp
+++ b/src/bricklink/order.cpp
@@ -16,6 +16,7 @@
 #include <QtSql/QSqlError>
 #include <QtSql/QSqlQueryModel>
 #include <QtCore/QLoggingCategory>
+#include <QtCore/QJsonValue>
 
 #include "bricklink/core.h"
 #include "bricklink/io.h"


### PR DESCRIPTION
Building the project was failing without this include on nixpkgs ([build log](https://hydra.nixos.org/build/295948128/nixlog/1)), but works with it added. Likely it was somehow implicitly found before, but this makes it explicit.

Note: while the log is with v2024.5.2, the same error occured on newest release v2024.12.3