### PR TITLE
Add an action to add items from multiple documents

### DIFF
--- a/src/common/actionmanager.cpp
+++ b/src/common/actionmanager.cpp
@@ -381,6 +381,7 @@ void ActionManager::initialize()
     A("edit_mergeitems",                QT_TR_NOOP("Consolidate Items..."), QT_TR_NOOP("Ctrl+L", "Edit|Consolidate Items"),  NeedSelection(2));
     A("edit_partoutitems",              QT_TR_NOOP("Part out Item..."),                                                      NeedInventory | NeedSelection(1) | NeedQuantity);
     A("edit_copy_fields",               QT_TR_NOOP("Copy Values from Document..."),                                          NeedDocument | NeedLots);
+    A("edit_additems_from_documents",   QT_TR_NOOP("Add Items from Documents..."),                                           NeedDocument);
     A("edit_select_all",                QT_TR_NOOP("Select All"),           QKeySequence::SelectAll,                         NeedDocument | NeedLots);
     A("edit_select_none",               QT_TR_NOOP("Select None"),          QT_TR_NOOP("Ctrl+Shift+A", "Edit|Select None"),  NeedDocument | NeedLots);
     // ^^ QKeySequence::Deselect is only mapped on Linux

--- a/src/common/documentmodel.cpp
+++ b/src/common/documentmodel.cpp
@@ -1530,7 +1530,7 @@ void DocumentModel::setCurrencyCode(const QString &ccode, double crate)
         m_undo->push(new CurrencyCmd(this, ccode, crate));
 }
 
-void DocumentModel::adjustLotCurrencyToModel(BrickLink::LotList &lots, const QString &fromCurrency)
+void DocumentModel::adjustLotCurrencyToModel(BrickLink::LotList &lots, const QString &fromCurrency) const
 {
     if (currencyCode() != fromCurrency) {
         double r = Currency::inst()->crossRate(fromCurrency, currencyCode());

--- a/src/common/documentmodel.h
+++ b/src/common/documentmodel.h
@@ -274,7 +274,7 @@ public:
     QString currencyCode() const;
     void setCurrencyCode(const QString &code, double crate = 1.);
 
-    void adjustLotCurrencyToModel(LotList &lots, const QString &fromCurrency);
+    void adjustLotCurrencyToModel(LotList &lots, const QString &fromCurrency) const;
 
     Filter::Parser *filterParser();
 

--- a/src/desktop/mainwindow.cpp
+++ b/src/desktop/mainwindow.cpp
@@ -726,6 +726,8 @@ void MainWindow::setupMenuBar()
                   "edit_reserved",
                   "edit_marker",
                   "-",
+                  "edit_additems_from_documents",
+                  "-",
                   "edit_copy_fields",
                   "-",
                   "bricklink_catalog",

--- a/src/desktop/selectdocumentdialog.h
+++ b/src/desktop/selectdocumentdialog.h
@@ -20,11 +20,11 @@ class SelectDocument : public QWidget
 {
     Q_OBJECT
 public:
-    SelectDocument(const DocumentModel *self, QWidget *parent = nullptr);
+    SelectDocument(const DocumentModel *self, bool multipleDocuments, QWidget *parent = nullptr);
     ~SelectDocument() override;
 
     bool isDocumentSelected() const;
-    BrickLink::LotList lots() const;
+    BrickLink::LotList lots(const DocumentModel *model) const;
     QString currencyCode() const;
 
 signals:
@@ -62,11 +62,10 @@ class SelectCopyMergeDialog : public QWizard
     Q_OBJECT
 public:
     SelectCopyMergeDialog(const DocumentModel *self, const QString &chooseDocText,
-                          const QString &chooseFieldsText, QWidget *parent = nullptr);
+                          const QString &chooseFieldsText, bool addDocuments, QWidget *parent = nullptr);
     ~SelectCopyMergeDialog() override;
 
-    LotList lots() const;
-    QString currencyCode() const;
+    LotList lots(const DocumentModel &model) const;
     QHash<DocumentModel::Field, DocumentModel::MergeMode> fieldMergeModes() const;
 
 protected:


### PR DESCRIPTION
This adds an action to add items from multiple opened documents. My use case for this is merging multiple BrickLink wanted lists.

It reuses the `SelectCopyMergeDialog` class for document selection and its `lots` method now does currency conversion too, as multiple documents may be involved.

This is similar to the requested feature in https://github.com/rgriebl/brickstore/issues/402.