### PR TITLE
Fix #1054 and update local Flatpak template

### DIFF
--- a/unix/flatpak.yaml.in
+++ b/unix/flatpak.yaml.in
@@ -1,7 +1,7 @@
 app-id: dev.brickstore.BrickStore
-runtime: org.gnome.Platform
-runtime-version: '46'
-sdk: org.gnome.Sdk
+runtime: org.kde.Platform
+runtime-version: '6.10'
+sdk: org.kde.Sdk
 command: brickstore
 modules:
   - name: brickstore
@@ -36,3 +36,4 @@ finish-args:
   - --device=dri
   - --device=all # webcam
   - --filesystem=home
+  - --env=QT_QPA_PLATFORM=wayland;xcb


### PR DESCRIPTION
Hi, I have found a solution for the recent Flatpak crash I reproted in #1054.

### Causes?
The crash has nothing to do with the Flatpak being old, it seems to be related to socket managment and how it interplays on Wayland currently with your application and the `socket=wayland`and `socket=fallback-x11`.

I found that there were recent changes in flatpak versions >1.17 made to the behaviour of the x11 fallback socket, and I observed the following thigs:
- Forcing Wayland usage with `QT_QPA_PLATFORM=wayland` fixed it. This suggests the xcb (x11) backend is somehow chosen first, and crashes because it is not present on Wayland.
- Changing the socket `socket=fallback-x11` to `socket=x11` allows the application to start, but it always runs as an X11 application
- Some Flatpak version around 1.17 changed the behaviour of the fallback-x11 socket according to issues on the Flatpak repository, thus it _could_ be related.

This points to an issue that could have been introduced either by Flatpak itself, or it is an issue in the QT behaviour of BrickStore exposed by these recent changes.

You might know better, if BrickStore does anything related to the `xcb` (X11) backend, or see sth I didn't when investigating #1054, but for now I have found a **workaround** to get a temporary fix out quickly:

### Fix
To get this working, I made the following changes:
- As a workaround introducing the environment variable QT_QPA_PLATFORM=wayland;xcb works to run the application properly on Wayland as well as on X11.
- Additionally, the runtimes were end-of-life, so I updated them to use the newest KDE runtimes (consistent with the Flathub runtimes which you would to use KDE Sdk for due to QT usage).

These are only minimal changes keeping your current Flatpak build process intact. 

I already tested it on my Fedora 44 system (Wayland) and on Linux Mint 22.3 (X11). You'd probably check it works the same with your GH Action workflow, but it should from what I saw.