### PR TITLE
Improve Appstream metadata for Flathub and introduce CMake option for Flathub offline builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ option(SENTRY       "Build with sentry.io support" OFF)
 option(VERBOSE_FETCH "Verbose output for 3rd party FetchContent" OFF)
 
 set(NAME           "BrickStore")
-set(DESCRIPTION    "${NAME} - an offline BrickLink inventory management tool")
+set(DESCRIPTION    "An offline BrickLink inventory management tool")
 set(COPYRIGHT      "2004-2026 Robert Griebl")
 set(BRICKSTORE_URL "www.brickstore.dev")
 set(GITHUB_URL     "github.com/rgriebl/brickstore")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ option(FORCE_MOBILE "Force a mobile build on desktop" OFF)
 option(SANITIZE     "Build with ASAN" OFF)
 option(MODELTEST    "Build with modeltest" OFF)
 option(SENTRY       "Build with sentry.io support" OFF)
+option(FLATHUB_NETWORK_OFF "Build for Flathub by disabling network fetch during build" OFF)
 option(VERBOSE_FETCH "Verbose output for 3rd party FetchContent" OFF)
 
 set(NAME           "BrickStore")

--- a/cmake/BuildQAdwaitaDecorations.cmake
+++ b/cmake/BuildQAdwaitaDecorations.cmake
@@ -1,18 +1,23 @@
 # Copyright (C) 2004-2026 Robert Griebl
 # SPDX-License-Identifier: GPL-3.0-only
 
-include(FetchContent)
-
 set(USE_QT6 ON)
 
-FetchContent_Declare(
-    qadwaitadecorations
-    GIT_REPOSITORY https://github.com/FedoraQt/QAdwaitaDecorations.git
-    GIT_TAG        f40f31dadc074bd989db6dd90e52eecf33c4567b  # 0.1.5 + border fix
-    SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
-)
+if(FLATHUB_NETWORK_OFF)
+  set(qadwaitadecorations_SOURCE_DIR "${CMAKE_SOURCE_DIR}/_deps/qadwaitadecorations-src")
+  set(qadwaitadecorations_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/qadwaitadecorations-build")
+else()
+  include(FetchContent)
 
-FetchContent_MakeAvailable(qadwaitadecorations)
+  FetchContent_Declare(
+      qadwaitadecorations
+      GIT_REPOSITORY https://github.com/FedoraQt/QAdwaitaDecorations.git
+      GIT_TAG        f40f31dadc074bd989db6dd90e52eecf33c4567b  # 0.1.5 + border fix
+      SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
+  )
+
+  FetchContent_MakeAvailable(qadwaitadecorations)
+endif()
 
 set(mll ${CMAKE_MESSAGE_LOG_LEVEL})
 if (NOT VERBOSE_FETCH)

--- a/cmake/BuildQCoro.cmake
+++ b/cmake/BuildQCoro.cmake
@@ -1,7 +1,6 @@
 # Copyright (C) 2004-2026 Robert Griebl
 # SPDX-License-Identifier: GPL-3.0-only
 
-include(FetchContent)
 
 set(QCORO_BUILD_EXAMPLES  OFF)
 set(QCORO_ENABLE_ASAN ${SANITIZE})
@@ -14,14 +13,21 @@ if (BACKEND_ONLY)
     set(QCORO_WITH_QML OFF)
 endif()
 
-FetchContent_Declare(
-    qcoro
-    GIT_REPOSITORY https://github.com/danvratil/qcoro.git
-    GIT_TAG        v${QCORO_VERSION}
-    SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
-)
+if(FLATHUB_NETWORK_OFF)
+  set(qcoro_SOURCE_DIR "${CMAKE_SOURCE_DIR}/_deps/qcoro-src")
+  set(qcoro_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/qcoro-build")
+else()
+  include(FetchContent)
 
-FetchContent_MakeAvailable(qcoro)
+  FetchContent_Declare(
+      qcoro
+      GIT_REPOSITORY https://github.com/danvratil/qcoro.gitls
+      GIT_TAG        v${QCORO_VERSION}
+      SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
+  )
+
+  FetchContent_MakeAvailable(qcoro)
+endif()
 
 set(mll ${CMAKE_MESSAGE_LOG_LEVEL})
 if (NOT VERBOSE_FETCH)

--- a/cmake/BuildSentry.cmake
+++ b/cmake/BuildSentry.cmake
@@ -1,16 +1,21 @@
 # Copyright (C) 2004-2026 Robert Griebl
 # SPDX-License-Identifier: GPL-3.0-only
 
-include(FetchContent)
+if(FLATHUB_NETWORK_OFF)
+  set(sentry_SOURCE_DIR "${CMAKE_SOURCE_DIR}/_deps/sentry-src")
+  set(sentry_BINARY_DIR "${CMAKE_BINARY_DIR}/_deps/sentry-build")
+else()
+  include(FetchContent)
 
-FetchContent_Declare(
-    sentry
-    GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
-    GIT_TAG        ${SENTRY_VERSION}
-    SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
-)
+  FetchContent_Declare(
+      sentry
+      GIT_REPOSITORY https://github.com/getsentry/sentry-native.git
+      GIT_TAG        ${SENTRY_VERSION}
+      SOURCE_SUBDIR  "NeedManualAddSubDir" # make it possible to add_subdirectory below
+  )
 
-FetchContent_MakeAvailable(sentry)
+  FetchContent_MakeAvailable(sentry)
+endif()
 
 set(mll ${CMAKE_MESSAGE_LOG_LEVEL})
 if (NOT VERBOSE_FETCH)

--- a/unix/dev.brickstore.BrickStore.metainfo.xml.in
+++ b/unix/dev.brickstore.BrickStore.metainfo.xml.in
@@ -4,6 +4,9 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-3.0-only</project_license>
   <name>BrickStore</name>
+  <developer id="org.griebl">
+    <name>Robert Griebl</name>
+  </developer>
   <summary>@DESCRIPTION@</summary>
   <content_rating type="oars-1.1" />
   <description>
@@ -11,7 +14,7 @@
 BrickStore is a BrickLink offline management tool. It is multi-platform (Windows, macOS, Linux, Android and iOS), multilingual (currently English, German, Spanish, Swedish and French), fast and stable.
 
 Some things you can do with BrickStore much more efficiently than with any web based interface:
-
+</p>
 <ul>
   <li>Browse and search the BrickLink catalog using a live, as-you-type filter. It is using all the cores in your machine to be as fast as possible.</li>
   <li>Easily create XML files for Mass-Upload and Mass-Update either by parting out sets or by adding individual parts (or both).</li>
@@ -24,7 +27,7 @@ Some things you can do with BrickStore much more efficiently than with any web b
   <li>Unlimited undo/redo support.</li>
   <li>Customized printing via JavaScript based page templates.</li>
 </ul>
-
+<p>
 BrickStore is free software licensed under the GNU General Public License (GPL) version 3, ©2004-2026 by Robert Griebl.
 
 All data from www.bricklink.com is owned by BrickLink. Both BrickLink and LEGO are trademarks of the LEGO group, which does not sponsor, authorize or endorse this software. All other trademarks are the property of their respective owners.
@@ -33,19 +36,27 @@ All data from www.bricklink.com is owned by BrickLink. Both BrickLink and LEGO a
 
   <launchable type="desktop-id">dev.brickstore.BrickStore.desktop</launchable>
 
+  <branding>
+    <color type="primary" scheme_preference="light">#97c5e2</color>
+    <color type="primary" scheme_preference="dark">#114566</color>
+  </branding>
   <screenshots>
     <screenshot type="default">
       <image>https://@BRICKSTORE_URL@/assets/screenshots/linux.jpg</image>
-    </screenshot>
-    <screenshot>
-      <image>https://@BRICKSTORE_URL@/assets/screenshots/macos.jpg</image>
-    </screenshot>
-    <screenshot>
-      <image>https://@BRICKSTORE_URL@/assets/screenshots/windows.jpg</image>
+      <caption>The main interface of BrickStore</caption>
     </screenshot>
   </screenshots>
 
+  <url type="bugtracker">https://@GITHUB_URL@/issues</url>
   <url type="homepage">https://@BRICKSTORE_URL@</url>
+  <url type="translate">https://@BRICKSTORE_URL@/translations</url>
+  <url type="vcs-browser">https://@GITHUB_URL@</url>
+
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+    <display_length compare="ge">768</display_length>
+  </recommends>
 
   <provides>
     <binary>brickstore</binary>


### PR DESCRIPTION
This pull request shows off some ready changes that would make it possible to submit the application to Flathub.

**The idea and process I have described in issue** #1057 
For details, please refer to it.

Again, hoping this helps and is not too overwhelming all at once, it is only everything submitted at once since I have already done it and feel like it would be incomplete if I were to only suggest some parts first.
Feel free to give feedback and suggest any changes, I will quickly remedy them.

Some details I feel are worth mentioning:
- The commits too have extensive descriptions of what I did.
- I removed the program name in the DESCRIPTION field as per: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/quality-guidelines#dont-repeat-the-name, and it seems unnecessary even for the other usages of DESCRIPTION as one always sees the appname too
- Other metainfo changes follow the outputs of validation tools like `appstreamcli validate --pedantic <file>` and `flatpak run --command=flatpak-builder-lint org.flatpak.Builder appstream <file>`. I put exact details on each point into the commit description as well.
-  The `FLATHUB_NETWORK_OFF` option is specifically built for a Flatpak build that pulls in QAdwaitaDecoration, QCoro and Sentry in respective directories under `_deps/` (as done in my suggested [dev.brickstore.BrickStore.yml](https://github.com/AlexanderRitter02/brickstore-dev.brickstore.BrickStore.yml/blob/master/dev.brickstore.BrickStore.yml) ).